### PR TITLE
List out compression and signature type

### DIFF
--- a/src/mardor/cli.py
+++ b/src/mardor/cli.py
@@ -107,6 +107,10 @@ def do_list(marfile, detailed=False):
     with open(marfile, 'rb') as f:
         with MarReader(f) as m:
             if detailed:
+                if m.compression_type:
+                    yield "Compression type: {}".format(m.compression_type)
+                if m.signature_type:
+                    yield "Signature type: {}".format(m.signature_type)
                 if m.mardata.signatures:
                     yield "Signature block found with {} signature".format(m.mardata.signatures.count)
                     for s in m.mardata.signatures.sigs:


### PR DESCRIPTION
_Simple patch, not urgent._

While debugging [Bug 1388431](https://bugzilla.mozilla.org/show_bug.cgi?id=1388431), we wanted to know whether a mar was bzip'd or lzma'd, and sha1'd or sha384'd.

This simple patch made helped us a. What do you think? 